### PR TITLE
rename references to `docli` with `doit`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 install:
   - "go get -d -v -t ./..."
-  - "go build github.com/bryanl/docli/cmd/docli"
+  - "go build github.com/bryanl/doit/cmd/docli"
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
 deploy:
@@ -22,6 +22,6 @@ wBtbwzJ/fk8NzpxDA06P3fSGP2AMLurdky+dVgohnOM/IC3yKMUV+SYvf8PezETk4GaJMND13xRfjh1Y
   file: "docli"
   skip_cleanup: true
   on:
-    repo: bryanl/docli
+    repo: bryanl/doit
     tags: true
     all_branches: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ it raises the chances we can quickly merge or address your contributions.
 ## Setting up Go to work on docli
 
 If you have never worked with Go before, you will have to complete the
-following steps in order to be able to compile and test docli.
+following steps in order to be able to compile and test doit.
 
-1. Install Go. Make sure the Go version is at least Go 1.4. 
+1. Install Go. Make sure the Go version is at least Go 1.4.
    Go 1.4. On a Mac, you can `brew install go` to install Go 1.4.
 
 1. Set and export the `GOPATH` environment variable and update your `PATH`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DOCLI
 
 
-![Travis Build Status](https://travis-ci.org/bryanl/docli.svg?branch=master)
+![Travis Build Status](https://travis-ci.org/bryanl/doit.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/bryanl/docli/badge.svg?branch=master)](https://coveralls.io/r/bryanl/docli?branch=master)
 
 
@@ -32,4 +32,4 @@ GLOBAL OPTIONS:
    --debug              Debug
    --help, -h           show help
    --version, -v        print the version
-```    
+```

--- a/account.go
+++ b/account.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"io"

--- a/account_test.go
+++ b/account_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"bufio"

--- a/actions.go
+++ b/actions.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"fmt"

--- a/actions_test.go
+++ b/actions_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/args.go
+++ b/args.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 const (
 	ArgActionID          = "action-id"

--- a/cmd/docli/account_commands.go
+++ b/cmd/docli/account_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -19,6 +19,6 @@ func accountGet() cli.Command {
 	return cli.Command{
 		Name:   "get",
 		Usage:  "get account",
-		Action: docli.AccountGet,
+		Action: doit.AccountGet,
 	}
 }

--- a/cmd/docli/actions_commands.go
+++ b/cmd/docli/actions_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -24,7 +24,7 @@ func actionList() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.ActionList,
+		Action: doit.ActionList,
 	}
 }
 
@@ -34,12 +34,12 @@ func actionGet() cli.Command {
 		Usage: "get action by id",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgActionID,
+				Name:  doit.ArgActionID,
 				Usage: "Action id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.ActionGet,
+		Action: doit.ActionGet,
 	}
 }

--- a/cmd/docli/domains_commands.go
+++ b/cmd/docli/domains_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -23,7 +23,7 @@ func domainList() cli.Command {
 	return cli.Command{
 		Name:   "list",
 		Usage:  "list domains",
-		Action: docli.DomainList,
+		Action: doit.DomainList,
 	}
 }
 
@@ -33,15 +33,15 @@ func domainCreate() cli.Command {
 		Usage: "create domain",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain name",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgIPAddress,
+				Name:  doit.ArgIPAddress,
 				Usage: "domain ip address",
 			},
 		},
-		Action: docli.DomainCreate,
+		Action: doit.DomainCreate,
 	}
 }
 
@@ -51,13 +51,13 @@ func domainGet() cli.Command {
 		Usage: "get domain",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain name",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DomainGet,
+		Action: doit.DomainGet,
 	}
 }
 
@@ -67,11 +67,11 @@ func domainDelete() cli.Command {
 		Usage: "delete domain",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain name",
 			},
 		},
-		Action: docli.DomainDelete,
+		Action: doit.DomainDelete,
 	}
 }
 
@@ -95,11 +95,11 @@ func recordList() cli.Command {
 		Usage: "list records",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain name",
 			},
 		},
-		Action: docli.RecordList,
+		Action: doit.RecordList,
 	}
 }
 
@@ -109,35 +109,35 @@ func recordCreate() cli.Command {
 		Usage: "create record",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "record domain (required)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordType,
+				Name:  doit.ArgRecordType,
 				Usage: "record type (required)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordName,
+				Name:  doit.ArgRecordName,
 				Usage: "record name (required for A, AAAA, CNAME, TXT, SRV records)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordData,
+				Name:  doit.ArgRecordData,
 				Usage: "record data (required for A, AAAA, CNAME, MX, TXT, SRV, NS records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordPriority,
+				Name:  doit.ArgRecordPriority,
 				Usage: "record priority (required for MX, SRV records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordPort,
+				Name:  doit.ArgRecordPort,
 				Usage: "record port (required for SRV records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordWeight,
+				Name:  doit.ArgRecordWeight,
 				Usage: "record weight (required for SRV records)",
 			},
 		},
-		Action: docli.RecordCreate,
+		Action: doit.RecordCreate,
 	}
 }
 
@@ -147,15 +147,15 @@ func recordGet() cli.Command {
 		Usage: "get domain record",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain name (required)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordID,
+				Name:  doit.ArgRecordID,
 				Usage: "domain id (required)",
 			},
 		},
-		Action: docli.RecordGet,
+		Action: doit.RecordGet,
 	}
 }
 
@@ -165,39 +165,39 @@ func recordUpdate() cli.Command {
 		Usage: "update domain record",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "record domain (required)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordID,
+				Name:  doit.ArgRecordID,
 				Usage: "record id (required)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordType,
+				Name:  doit.ArgRecordType,
 				Usage: "record type (required)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordName,
+				Name:  doit.ArgRecordName,
 				Usage: "record name (required for A, AAAA, CNAME, TXT, SRV records)",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRecordData,
+				Name:  doit.ArgRecordData,
 				Usage: "record data (required for A, AAAA, CNAME, MX, TXT, SRV, NS records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordPriority,
+				Name:  doit.ArgRecordPriority,
 				Usage: "record priority (required for MX, SRV records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordPort,
+				Name:  doit.ArgRecordPort,
 				Usage: "record port (required for SRV records)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordWeight,
+				Name:  doit.ArgRecordWeight,
 				Usage: "record weight (required for SRV records)",
 			},
 		},
-		Action: docli.RecordUpdate,
+		Action: doit.RecordUpdate,
 	}
 }
 
@@ -207,14 +207,14 @@ func recordDelete() cli.Command {
 		Usage: "delete domain record",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDomainName,
+				Name:  doit.ArgDomainName,
 				Usage: "domain (required)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgRecordID,
+				Name:  doit.ArgRecordID,
 				Usage: "record id (required)",
 			},
 		},
-		Action: docli.RecordDelete,
+		Action: doit.RecordDelete,
 	}
 }

--- a/cmd/docli/droplet_action_commands.go
+++ b/cmd/docli/droplet_action_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -30,52 +30,52 @@ func dropletActionCommands() cli.Command {
 }
 
 func dropletDisableBackups() cli.Command {
-	fn := docli.DropletActionDisableBackups
+	fn := doit.DropletActionDisableBackups
 	return noArgDropletCommand("disable-backups", "disables backups for droplet", fn)
 }
 
 func dropletReboot() cli.Command {
-	fn := docli.DropletActionReboot
+	fn := doit.DropletActionReboot
 	return noArgDropletCommand("reboot", "reboot droplet", fn)
 }
 
 func dropletPowerCycle() cli.Command {
-	fn := docli.DropletActionPowerCycle
+	fn := doit.DropletActionPowerCycle
 	return noArgDropletCommand("power-cycle", "power cyle droplet", fn)
 }
 
 func dropletShutdown() cli.Command {
-	fn := docli.DropletActionShutdown
+	fn := doit.DropletActionShutdown
 	return noArgDropletCommand("shutdown", "shutdown droplet", fn)
 }
 
 func dropletPowerOff() cli.Command {
-	fn := docli.DropletActionPowerOff
+	fn := doit.DropletActionPowerOff
 	return noArgDropletCommand("power-off", "power off droplet", fn)
 }
 
 func dropletPowerOn() cli.Command {
-	fn := docli.DropletActionPowerOn
+	fn := doit.DropletActionPowerOn
 	return noArgDropletCommand("power-on", "power on droplet", fn)
 }
 
 func dropletPasswordReset() cli.Command {
-	fn := docli.DropletActionPasswordReset
+	fn := doit.DropletActionPasswordReset
 	return noArgDropletCommand("password-reset", "reset password for droplet", fn)
 }
 
 func dropletEnableIPv6() cli.Command {
-	fn := docli.DropletActionEnableIPv6
+	fn := doit.DropletActionEnableIPv6
 	return noArgDropletCommand("power-on", "enable ipv6 for droplet", fn)
 }
 
 func dropletEnablePrivateNetworking() cli.Command {
-	fn := docli.DropletActionPasswordReset
+	fn := doit.DropletActionPasswordReset
 	return noArgDropletCommand("private-networking", "enable private networking for droplet", fn)
 }
 
 func dropletUpgrade() cli.Command {
-	fn := docli.DropletActionUpgrade
+	fn := doit.DropletActionUpgrade
 	return noArgDropletCommand("upgrade", "upgrade droplet", fn)
 }
 
@@ -96,7 +96,7 @@ func dropletRestore() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionRestore,
+		Action: doit.DropletActionRestore,
 	}
 }
 
@@ -120,7 +120,7 @@ func dropletResize() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionResize,
+		Action: doit.DropletActionResize,
 	}
 }
 
@@ -140,7 +140,7 @@ func dropletRebuild() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionRebuild,
+		Action: doit.DropletActionRebuild,
 	}
 }
 
@@ -160,7 +160,7 @@ func dropletRename() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionRename,
+		Action: doit.DropletActionRename,
 	}
 }
 
@@ -180,7 +180,7 @@ func dropletChangeKernel() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionChangeKernel,
+		Action: doit.DropletActionChangeKernel,
 	}
 }
 
@@ -200,7 +200,7 @@ func dropletSnapshot() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionSnapshot,
+		Action: doit.DropletActionSnapshot,
 	}
 }
 
@@ -238,6 +238,6 @@ func dropletActionGet() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActionGet,
+		Action: doit.DropletActionGet,
 	}
 }

--- a/cmd/docli/droplet_commands.go
+++ b/cmd/docli/droplet_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -31,7 +31,7 @@ func dropletList() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletList,
+		Action: doit.DropletList,
 	}
 }
 
@@ -42,46 +42,46 @@ func dropletCreate() cli.Command {
 		Flags: []cli.Flag{
 
 			cli.StringFlag{
-				Name:  docli.ArgDropletName,
+				Name:  doit.ArgDropletName,
 				Usage: "droplet name",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRegionSlug,
+				Name:  doit.ArgRegionSlug,
 				Usage: "droplet region",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgSizeSlug,
+				Name:  doit.ArgSizeSlug,
 				Usage: "droplet size",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgImage,
+				Name:  doit.ArgImage,
 				Usage: "droplet image",
 			},
 			cli.StringSliceFlag{
-				Name:  docli.ArgSSHKeys,
+				Name:  doit.ArgSSHKeys,
 				Value: &cli.StringSlice{},
 				Usage: "droplet public SSH keys",
 			},
 			cli.BoolFlag{
-				Name:  docli.ArgBackups,
+				Name:  doit.ArgBackups,
 				Usage: "enable droplet backups",
 			},
 			cli.BoolFlag{
-				Name:  docli.ArgIPv6,
+				Name:  doit.ArgIPv6,
 				Usage: "enable droplet IPv6",
 			},
 			cli.BoolFlag{
-				Name:  docli.ArgPrivateNetworking,
+				Name:  doit.ArgPrivateNetworking,
 				Usage: "enable droplet private networking",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgUserData,
+				Name:  doit.ArgUserData,
 				Usage: "droplet name",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletCreate,
+		Action: doit.DropletCreate,
 	}
 }
 
@@ -91,11 +91,11 @@ func dropletDelete() cli.Command {
 		Usage: "delete droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 		},
-		Action: docli.DropletDelete,
+		Action: doit.DropletDelete,
 	}
 }
 
@@ -105,13 +105,13 @@ func dropletGet() cli.Command {
 		Usage: "get droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletGet,
+		Action: doit.DropletGet,
 	}
 }
 
@@ -121,13 +121,13 @@ func dropletKernels() cli.Command {
 		Usage: "get kernels for droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletKernels,
+		Action: doit.DropletKernels,
 	}
 }
 
@@ -137,13 +137,13 @@ func dropletSnapshots() cli.Command {
 		Usage: "get snapshots for droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletSnapshots,
+		Action: doit.DropletSnapshots,
 	}
 }
 
@@ -153,13 +153,13 @@ func dropletBackups() cli.Command {
 		Usage: "get backups for droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletBackups,
+		Action: doit.DropletBackups,
 	}
 }
 
@@ -169,13 +169,13 @@ func dropletActions() cli.Command {
 		Usage: "get actions for droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletActions,
+		Action: doit.DropletActions,
 	}
 }
 
@@ -185,12 +185,12 @@ func dropletNeighbors() cli.Command {
 		Usage: "get neighbors for droplet",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.DropletNeighbors,
+		Action: doit.DropletNeighbors,
 	}
 }

--- a/cmd/docli/image_action_commands.go
+++ b/cmd/docli/image_action_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -22,17 +22,17 @@ func imageActionGet() cli.Command {
 		Usage: "get image action",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgImageID,
+				Name:  doit.ArgImageID,
 				Usage: "image id",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgActionID,
+				Name:  doit.ArgActionID,
 				Usage: "action id",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.ImageActionsGet,
+		Action: doit.ImageActionsGet,
 	}
 }
 
@@ -42,16 +42,16 @@ func imageActionTransfer() cli.Command {
 		Usage: "tranfser image (not implemented)",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgImageID,
+				Name:  doit.ArgImageID,
 				Usage: "image id",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgRegionSlug,
+				Name:  doit.ArgRegionSlug,
 				Usage: "region",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.ImageActionsTransfer,
+		Action: doit.ImageActionsTransfer,
 	}
 }

--- a/cmd/docli/image_commands.go
+++ b/cmd/docli/image_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -26,7 +26,7 @@ func imageList() cli.Command {
 	return cli.Command{
 		Name:   "list",
 		Usage:  "list images",
-		Action: docli.ImagesList,
+		Action: doit.ImagesList,
 	}
 }
 
@@ -34,7 +34,7 @@ func imageListDistributions() cli.Command {
 	return cli.Command{
 		Name:   "list-distribution",
 		Usage:  "list distribution images",
-		Action: docli.ImagesListDistribution,
+		Action: doit.ImagesListDistribution,
 	}
 }
 
@@ -42,7 +42,7 @@ func imageListApplication() cli.Command {
 	return cli.Command{
 		Name:   "list-application",
 		Usage:  "list application images",
-		Action: docli.ImagesListApplication,
+		Action: doit.ImagesListApplication,
 	}
 }
 
@@ -50,7 +50,7 @@ func imageListUser() cli.Command {
 	return cli.Command{
 		Name:   "list-user",
 		Usage:  "list user images",
-		Action: docli.ImagesListUser,
+		Action: doit.ImagesListUser,
 	}
 }
 
@@ -60,11 +60,11 @@ func imageGet() cli.Command {
 		Usage: "get image by id",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgImage,
+				Name:  doit.ArgImage,
 				Usage: "image id or slug",
 			},
 		},
-		Action: docli.ImagesGet,
+		Action: doit.ImagesGet,
 	}
 }
 
@@ -74,7 +74,7 @@ func imageActions() cli.Command {
 		Usage: "image actions",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgImageID,
+				Name:  doit.ArgImageID,
 				Usage: "image id",
 			},
 		},
@@ -87,15 +87,15 @@ func imageUpdate() cli.Command {
 		Usage: "update image (not implemented)",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgImageID,
+				Name:  doit.ArgImageID,
 				Usage: "image id (required)",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgImageName,
+				Name:  doit.ArgImageName,
 				Usage: "image name (required)",
 			},
 		},
-		Action: docli.ImagesUpdate,
+		Action: doit.ImagesUpdate,
 	}
 }
 
@@ -105,10 +105,10 @@ func imageDelete() cli.Command {
 		Usage: "delete image",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgImageID,
+				Name:  doit.ArgImageID,
 				Usage: "image id (required)",
 			},
 		},
-		Action: docli.ImagesDelete,
+		Action: doit.ImagesDelete,
 	}
 }

--- a/cmd/docli/main.go
+++ b/cmd/docli/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 	"golang.org/x/oauth2"
 )
@@ -23,7 +23,7 @@ func init() {
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.InfoLevel)
 
-	docli.Bail = func(err error, msg string) {
+	doit.Bail = func(err error, msg string) {
 		logrus.WithField("err", err).Fatal(msg)
 	}
 }
@@ -72,14 +72,14 @@ func debugFlag() cli.Flag {
 
 func jsonFlag() cli.Flag {
 	return cli.BoolFlag{
-		Name:  docli.ArgDisplayJSON,
+		Name:  doit.ArgDisplayJSON,
 		Usage: "display JSON output",
 	}
 }
 
 func textFlag() cli.Flag {
 	return cli.BoolFlag{
-		Name:  docli.ArgDisplayText,
+		Name:  doit.ArgDisplayText,
 		Usage: "display text output",
 	}
 }

--- a/cmd/docli/region_commands.go
+++ b/cmd/docli/region_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -23,6 +23,6 @@ func regionList() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.RegionList,
+		Action: doit.RegionList,
 	}
 }

--- a/cmd/docli/size_commands.go
+++ b/cmd/docli/size_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -23,6 +23,6 @@ func sizeList() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.SizeList,
+		Action: doit.SizeList,
 	}
 }

--- a/cmd/docli/ssh_commands.go
+++ b/cmd/docli/ssh_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -11,18 +11,18 @@ func sshCommands() cli.Command {
 		Usage: "SSH to droplet. Provide name or id",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgDropletName,
+				Name:  doit.ArgDropletName,
 				Usage: "droplet name",
 			},
 			cli.IntFlag{
-				Name:  docli.ArgDropletID,
+				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgSSHUser,
+				Name:  doit.ArgSSHUser,
 				Usage: "ssh user",
 			},
 		},
-		Action: docli.SSH,
+		Action: doit.SSH,
 	}
 }

--- a/cmd/docli/ssh_key_commands.go
+++ b/cmd/docli/ssh_key_commands.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bryanl/docli"
+	"github.com/bryanl/doit"
 	"github.com/codegangsta/cli"
 )
 
@@ -27,7 +27,7 @@ func sshKeyList() cli.Command {
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.KeyList,
+		Action: doit.KeyList,
 	}
 }
 
@@ -37,17 +37,17 @@ func sshKeyCreate() cli.Command {
 		Usage: "create ssh key",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgKeyName,
+				Name:  doit.ArgKeyName,
 				Usage: "ssh key name",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgKeyPublicKey,
+				Name:  doit.ArgKeyPublicKey,
 				Usage: "ssh public key",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.KeyCreate,
+		Action: doit.KeyCreate,
 	}
 }
 
@@ -57,13 +57,13 @@ func sshKeyGet() cli.Command {
 		Usage: "get ssh key",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgKey,
+				Name:  doit.ArgKey,
 				Usage: "ssh key id or fingerprint",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.KeyGet,
+		Action: doit.KeyGet,
 	}
 }
 
@@ -73,17 +73,17 @@ func sshKeyUpdate() cli.Command {
 		Usage: "update ssh key",
 		Flags: []cli.Flag{
 			cli.IntFlag{
-				Name:  docli.ArgKey,
+				Name:  doit.ArgKey,
 				Usage: "ssh key id",
 			},
 			cli.StringFlag{
-				Name:  docli.ArgKeyName,
+				Name:  doit.ArgKeyName,
 				Usage: "ssh key name",
 			},
 			jsonFlag(),
 			textFlag(),
 		},
-		Action: docli.KeyUpdate,
+		Action: doit.KeyUpdate,
 	}
 }
 
@@ -93,10 +93,10 @@ func sshKeyDelete() cli.Command {
 		Usage: "delete ssh key",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  docli.ArgKey,
+				Name:  doit.ArgKey,
 				Usage: "ssh key id or fingerprint",
 			},
 		},
-		Action: docli.KeyDelete,
+		Action: doit.KeyDelete,
 	}
 }

--- a/display.go
+++ b/display.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"bytes"

--- a/docli.go
+++ b/docli.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 var (
 	Bail func(err error, msg string)

--- a/docli_test.go
+++ b/docli_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"os"

--- a/domainrecs.go
+++ b/domainrecs.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/domainrecs_test.go
+++ b/domainrecs_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/domains.go
+++ b/domains.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/domains_test.go
+++ b/domains_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/dropletactions.go
+++ b/dropletactions.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"strconv"

--- a/dropletactions_test.go
+++ b/dropletactions_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/droplets.go
+++ b/droplets.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"strconv"

--- a/droplets_test.go
+++ b/droplets_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/godo_util.go
+++ b/godo_util.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"fmt"

--- a/image_actions.go
+++ b/image_actions.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/image_actions_test.go
+++ b/image_actions_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/images.go
+++ b/images.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"fmt"

--- a/images_test.go
+++ b/images_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/mock_godo.go
+++ b/mock_godo.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import "github.com/digitalocean/godo"
 

--- a/opts.go
+++ b/opts.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 type Opts struct {
 	Debug bool

--- a/pagination.go
+++ b/pagination.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"net/url"

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import "testing"
 

--- a/regions.go
+++ b/regions.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/regions_test.go
+++ b/regions_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/sizes.go
+++ b/sizes.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/sizes_test.go
+++ b/sizes_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/ssh.go
+++ b/ssh.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"fmt"

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/sshkeys.go
+++ b/sshkeys.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"fmt"

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"flag"

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package docli
+package doit
 
 import (
 	"bufio"


### PR DESCRIPTION
I see you renamed the repo, this applies the change across the codebase and fix the build of `cmd/docli`.
@bryanl 