### PR TITLE
Add support for a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # DOIT
 
-
 ![Travis Build Status](https://travis-ci.org/bryanl/doit.svg?branch=master)
 [![Coverage Status]
 (https://coveralls.io/repos/bryanl/doit/badge.svg?branch=master)]
@@ -37,3 +36,19 @@ GLOBAL OPTIONS:
    --version, -v   print the version
 
 ```
+## Configuration
+
+By default, `doit` will load a configuration file from `$HOME/.doitcfg` if found.
+
+### Configuration OPTIONS
+
+* `token` - The DigitalOcean token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel.
+* `output` - Type of output to display results in. Choices are `json` or `text`. If not supplied, `doit` will default to `text`.
+
+Example:
+
+```yaml
+{
+  token: MY_TOKEN
+  output: text
+}

--- a/args.go
+++ b/args.go
@@ -34,6 +34,5 @@ const (
 	ArgSSHUser           = "ssh-user"
 
 	// Arguments for outputs
-	ArgDisplayJSON = "json"
-	ArgDisplayText = "text"
+	ArgOutput = "output"
 )

--- a/cmd/doit/actions_commands.go
+++ b/cmd/doit/actions_commands.go
@@ -18,12 +18,8 @@ func actionCommands() cli.Command {
 
 func actionList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list actions",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list actions",
 		Action: doit.ActionList,
 	}
 }
@@ -37,8 +33,6 @@ func actionGet() cli.Command {
 				Name:  doit.ArgActionID,
 				Usage: "Action id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.ActionGet,
 	}

--- a/cmd/doit/domains_commands.go
+++ b/cmd/doit/domains_commands.go
@@ -54,8 +54,6 @@ func domainGet() cli.Command {
 				Name:  doit.ArgDomainName,
 				Usage: "domain name",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DomainGet,
 	}

--- a/cmd/doit/droplet_action_commands.go
+++ b/cmd/doit/droplet_action_commands.go
@@ -93,8 +93,6 @@ func dropletRestore() cli.Command {
 				Name:  "image",
 				Usage: "image slug or id (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionRestore,
 	}
@@ -117,8 +115,6 @@ func dropletResize() cli.Command {
 				Name:  "disk",
 				Usage: "increase disk size",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionResize,
 	}
@@ -137,8 +133,6 @@ func dropletRebuild() cli.Command {
 				Name:  "image",
 				Usage: "image slug or image id (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionRebuild,
 	}
@@ -157,8 +151,6 @@ func dropletRename() cli.Command {
 				Name:  "name",
 				Usage: "new name for droplet (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionRename,
 	}
@@ -177,8 +169,6 @@ func dropletChangeKernel() cli.Command {
 				Name:  "kernel",
 				Usage: "new kernel for droplet (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionChangeKernel,
 	}
@@ -197,8 +187,6 @@ func dropletSnapshot() cli.Command {
 				Name:  "name",
 				Usage: "name for snapshot",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionSnapshot,
 	}
@@ -215,8 +203,6 @@ func noArgDropletCommand(name, usage string, fn noArgDropletFn) cli.Command {
 				Name:  "id",
 				Usage: "droplet id (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: fn,
 	}
@@ -235,8 +221,6 @@ func dropletActionGet() cli.Command {
 				Name:  "action-id",
 				Usage: "action id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActionGet,
 	}

--- a/cmd/doit/droplet_commands.go
+++ b/cmd/doit/droplet_commands.go
@@ -25,12 +25,8 @@ func dropletCommands() cli.Command {
 
 func dropletList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list droplets",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list droplets",
 		Action: doit.DropletList,
 	}
 }
@@ -82,8 +78,6 @@ func dropletCreate() cli.Command {
 				Name:  doit.ArgUserDataFile,
 				Usage: "reads droplet user data from a file",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletCreate,
 	}
@@ -112,8 +106,6 @@ func dropletGet() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletGet,
 	}
@@ -128,8 +120,6 @@ func dropletKernels() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletKernels,
 	}
@@ -144,8 +134,6 @@ func dropletSnapshots() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletSnapshots,
 	}
@@ -160,8 +148,6 @@ func dropletBackups() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletBackups,
 	}
@@ -176,8 +162,6 @@ func dropletActions() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletActions,
 	}
@@ -192,8 +176,6 @@ func dropletNeighbors() cli.Command {
 				Name:  doit.ArgDropletID,
 				Usage: "droplet id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.DropletNeighbors,
 	}

--- a/cmd/doit/image_action_commands.go
+++ b/cmd/doit/image_action_commands.go
@@ -29,8 +29,6 @@ func imageActionGet() cli.Command {
 				Name:  doit.ArgActionID,
 				Usage: "action id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.ImageActionsGet,
 	}
@@ -49,8 +47,6 @@ func imageActionTransfer() cli.Command {
 				Name:  doit.ArgRegionSlug,
 				Usage: "region",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.ImageActionsTransfer,
 	}

--- a/cmd/doit/image_commands.go
+++ b/cmd/doit/image_commands.go
@@ -24,48 +24,36 @@ func imageCommands() cli.Command {
 
 func imageList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list images",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list images",
+		Flags:  []cli.Flag{},
 		Action: doit.ImagesList,
 	}
 }
 
 func imageListDistributions() cli.Command {
 	return cli.Command{
-		Name:  "list-distribution",
-		Usage: "list distribution images",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list-distribution",
+		Usage:  "list distribution images",
+		Flags:  []cli.Flag{},
 		Action: doit.ImagesListDistribution,
 	}
 }
 
 func imageListApplication() cli.Command {
 	return cli.Command{
-		Name:  "list-application",
-		Usage: "list application images",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list-application",
+		Usage:  "list application images",
+		Flags:  []cli.Flag{},
 		Action: doit.ImagesListApplication,
 	}
 }
 
 func imageListUser() cli.Command {
 	return cli.Command{
-		Name:  "list-user",
-		Usage: "list user images",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list-user",
+		Usage:  "list user images",
+		Flags:  []cli.Flag{},
 		Action: doit.ImagesListUser,
 	}
 }
@@ -79,8 +67,6 @@ func imageGet() cli.Command {
 				Name:  doit.ArgImage,
 				Usage: "image id or slug",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.ImagesGet,
 	}
@@ -95,8 +81,6 @@ func imageActions() cli.Command {
 				Name:  doit.ArgImageID,
 				Usage: "image id",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 	}
 }
@@ -114,8 +98,6 @@ func imageUpdate() cli.Command {
 				Name:  doit.ArgImageName,
 				Usage: "image name (required)",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.ImagesUpdate,
 	}

--- a/cmd/doit/region_commands.go
+++ b/cmd/doit/region_commands.go
@@ -17,12 +17,8 @@ func regionCommands() cli.Command {
 
 func regionList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list regions",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list regions",
 		Action: doit.RegionList,
 	}
 }

--- a/cmd/doit/size_commands.go
+++ b/cmd/doit/size_commands.go
@@ -17,12 +17,8 @@ func sizeCommands() cli.Command {
 
 func sizeList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list sizes",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list sizes",
 		Action: doit.SizeList,
 	}
 }

--- a/cmd/doit/ssh_key_commands.go
+++ b/cmd/doit/ssh_key_commands.go
@@ -21,12 +21,8 @@ func sshKeyCommands() cli.Command {
 
 func sshKeyList() cli.Command {
 	return cli.Command{
-		Name:  "list",
-		Usage: "list ssh keys",
-		Flags: []cli.Flag{
-			jsonFlag(),
-			textFlag(),
-		},
+		Name:   "list",
+		Usage:  "list ssh keys",
 		Action: doit.KeyList,
 	}
 }
@@ -44,8 +40,6 @@ func sshKeyCreate() cli.Command {
 				Name:  doit.ArgKeyPublicKey,
 				Usage: "ssh public key",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.KeyCreate,
 	}
@@ -60,8 +54,6 @@ func sshKeyGet() cli.Command {
 				Name:  doit.ArgKey,
 				Usage: "ssh key id or fingerprint",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.KeyGet,
 	}
@@ -80,8 +72,6 @@ func sshKeyUpdate() cli.Command {
 				Name:  doit.ArgKeyName,
 				Usage: "ssh key name",
 			},
-			jsonFlag(),
-			textFlag(),
 		},
 		Action: doit.KeyUpdate,
 	}

--- a/config_file.go
+++ b/config_file.go
@@ -1,0 +1,63 @@
+package doit
+
+import (
+	"sort"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ConfigArgMap map[string]string
+
+type ConfigFile struct {
+	contents []byte
+	argMap   ConfigArgMap
+}
+
+func NewConfigFile(argMap ConfigArgMap, c []byte) *ConfigFile {
+	return &ConfigFile{
+		argMap:   argMap,
+		contents: c,
+	}
+}
+
+func (cf *ConfigFile) Args() ([]string, error) {
+	a := []string{}
+	c := map[string]interface{}{}
+
+	err := yaml.Unmarshal(cf.contents, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	mk := []string{}
+	for k := range cf.argMap {
+		mk = append(mk, k)
+	}
+
+	sort.Strings(mk)
+	am := cf.argMap
+	for _, k := range mk {
+		v2 := c[k]
+		arg := "--" + am[k]
+
+		var val string
+		switch v2.(type) {
+		default:
+			val = v2.(string)
+			a = append(a, arg, val)
+		case bool:
+			if v2.(bool) {
+				a = append(a, arg)
+			}
+		case nil:
+			// noop
+		}
+
+	}
+
+	return a, nil
+}
+
+func InsertArgs(osArgs, newArgs []string) []string {
+	return append(osArgs[:1], append(newArgs, osArgs[1:]...)...)
+}

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -1,0 +1,45 @@
+package doit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateArgs(t *testing.T) {
+	argMap := ConfigArgMap{
+		"t1": "test1",
+		"t2": "test2",
+	}
+
+	cfg := `
+t1: ex1
+t2: ex2`
+
+	expected := []string{
+		"--test1", "ex1",
+		"--test2", "ex2",
+	}
+
+	cf := NewConfigFile(argMap, []byte(cfg))
+	got, err := cf.Args()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestInsertArgs(t *testing.T) {
+	newArgs := []string{
+		"--foo", "bar",
+	}
+
+	osargs := []string{
+		"myapp", "action",
+	}
+
+	got := InsertArgs(osargs, newArgs)
+	expected := []string{
+		"myapp", "--foo", "bar", "action",
+	}
+
+	assert.Equal(t, expected, got)
+}

--- a/display.go
+++ b/display.go
@@ -13,11 +13,19 @@ import (
 )
 
 func displayOutput(c *cli.Context, item interface{}) error {
-	if c.Bool(ArgDisplayText) {
-		return writeText(item, c.App.Writer)
+	output := c.GlobalString(ArgOutput)
+	if len(output) < 1 {
+		output = "text"
 	}
 
-	return writeJSON(item, c.App.Writer)
+	switch output {
+	case "json":
+		return writeJSON(item, c.App.Writer)
+	case "text":
+		return writeText(item, c.App.Writer)
+	default:
+		return fmt.Errorf("unknown output type")
+	}
 }
 
 func writeJSON(item interface{}, w io.Writer) error {

--- a/docli_test.go
+++ b/docli_test.go
@@ -9,13 +9,22 @@ import (
 
 var (
 	testDroplet = godo.Droplet{
-		ID:   1,
+		ID: 1,
+		Image: &godo.Image{
+			ID:           1,
+			Name:         "an-image",
+			Distribution: "DOOS",
+		},
 		Name: "a-droplet",
 		Networks: &godo.Networks{
 			V4: []godo.NetworkV4{
 				{IPAddress: "8.8.8.8", Type: "public"},
 				{IPAddress: "172.16.1.2", Type: "private"},
 			},
+		},
+		Region: &godo.Region{
+			Slug: "test0",
+			Name: "test 0",
 		},
 	}
 	testDropletList = []godo.Droplet{testDroplet}

--- a/images.go
+++ b/images.go
@@ -168,6 +168,7 @@ func ImagesGet(c *cli.Context) {
 
 	if err != nil {
 		Bail(err, "could not retrieve image")
+		return
 	}
 
 	err = displayOutput(c, image)
@@ -188,6 +189,7 @@ func ImagesUpdate(c *cli.Context) {
 	image, _, err := client.Images.Update(id, req)
 	if err != nil {
 		Bail(err, "could not update image")
+		return
 	}
 
 	err = displayOutput(c, image)

--- a/images_test.go
+++ b/images_test.go
@@ -2,6 +2,7 @@ package doit
 
 import (
 	"flag"
+	"fmt"
 	"testing"
 
 	"github.com/codegangsta/cli"
@@ -10,7 +11,11 @@ import (
 )
 
 var (
-	testImage     = godo.Image{ID: 1, Slug: "slug"}
+	testImage = godo.Image{
+		ID:      1,
+		Slug:    "slug",
+		Regions: []string{"test0"},
+	}
 	testImageList = []godo.Image{testImage}
 )
 
@@ -173,11 +178,11 @@ func TestImagesNoID(t *testing.T) {
 		Images: &ImagesServiceMock{
 			GetByIDFn: func(id int) (*godo.Image, *godo.Response, error) {
 				t.Error("should not try to load id")
-				return nil, nil, nil
+				return nil, nil, fmt.Errorf("not here")
 			},
 			GetBySlugFn: func(slug string) (*godo.Image, *godo.Response, error) {
 				t.Error("should not try to load slug")
-				return &testImage, nil, nil
+				return nil, nil, fmt.Errorf("not here")
 			},
 		},
 	}


### PR DESCRIPTION
By default, `doit` will load a configuration file from `$HOME/.doitcfg` if found.

* `token` - The DigitalOcean token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel.
* `output` - Type of output to display results in. Choices are `json` or `text`. If not supplied, `doit` will default to `text`.

Example:

```yaml
{
  token: MY_TOKEN
  output: text
}