### PR TITLE
rename token -> access-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ COMMANDS:
    help, h		Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --token 		DigitalOcean API V2 Token [$DIGITAL_OCEAN_TOKEN]
+   --access-token 		DigitalOcean API V2 Access Token [$DIGITALOCEAN_ACCESS_TOKEN]
    --debug		Debug
    --output 		output format (json or text)
    --help, -h		show help
@@ -43,18 +43,18 @@ By default, `doit` will load a configuration file from `$HOME/.doitcfg` if found
 
 ### Configuration OPTIONS
 
-* `token` - The DigitalOcean token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel.
+* `access-token` - The DigitalOcean access token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel.
 * `output` - Type of output to display results in. Choices are `json` or `text`. If not supplied, `doit` will default to `text`.
 
 Example:
 
 ```yaml
 {
-  token: MY_TOKEN
+  access-token: MY_TOKEN
   output: text
 }
 ```
 
 ## Plugins
 
-`doit` functionality can be enhanced using plugins. 
+`doit` functionality can be enhanced using plugins.

--- a/commands/doit.go
+++ b/commands/doit.go
@@ -35,7 +35,7 @@ var (
 func init() {
 	viper.SetConfigType("yaml")
 
-	DoitCmd.PersistentFlags().StringVarP(&Token, "token", "t", "", "DigtialOcean API V2 Token")
+	DoitCmd.PersistentFlags().StringVarP(&Token, "access-token", "t", "", "DigtialOcean API V2 Access Token")
 	DoitCmd.PersistentFlags().StringVarP(&Output, "output", "o", "text", "output formt [text|json]")
 }
 
@@ -80,8 +80,8 @@ func addCommands() {
 
 func initFlags() {
 	viper.SetEnvPrefix("DIGITALOCEAN")
-	viper.BindEnv("token", "ACCESS_TOKEN")
-	viper.BindPFlag("token", DoitCmd.PersistentFlags().Lookup("token"))
+	viper.BindEnv("access-token", "DIGITALOCEAN_ACCESS_TOKEN")
+	viper.BindPFlag("access-token", DoitCmd.PersistentFlags().Lookup("access-token"))
 	viper.BindPFlag("output", DoitCmd.PersistentFlags().Lookup("output"))
 }
 
@@ -95,8 +95,8 @@ func initializeConfig() {
 	LoadConfig()
 	initFlags()
 
-	if DoitCmd.PersistentFlags().Lookup("token").Changed {
-		viper.Set("token", Token)
+	if DoitCmd.PersistentFlags().Lookup("access-token").Changed {
+		viper.Set("access-token", Token)
 	}
 
 	if DoitCmd.PersistentFlags().Lookup("output").Changed {

--- a/doit.go
+++ b/doit.go
@@ -34,7 +34,7 @@ var _ Config = &LiveConfig{}
 
 // GetGodoClient returns a GodoClient.
 func (c *LiveConfig) GetGodoClient() *godo.Client {
-	token := viper.GetString("token")
+	token := viper.GetString("access-token")
 	tokenSource := &TokenSource{AccessToken: token}
 	oauthClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
 	return godo.NewClient(oauthClient)


### PR DESCRIPTION
This also fixes the bug where `DIGITALOCEAN_ACCESS_TOKEN` was not being read, but `ACCESS_TOKEN` was. I also changed the `token` field in the config file to be `access-token` so that it is consistent with the environment variable and command line flag.