### PR TITLE
add cli support for doit auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use "doit [command] --help" for more information about a command.
 
 ## Initialization
 
+To automatically retrieve your access token from DigitalOcean, run `doit auth login`. This process will authenticate you with DigitalOcean and retrieve an access token. If your shell does not have access to a web browser (because of a remote Linux shell with no DISPLAY environment variable or you've specified the CLIAUTH=1 flag), `doit` will provide you with a link for offline authentication.
 
 
 
@@ -44,7 +45,7 @@ By default, `doit` will load a configuration file from `$HOME/.doitcfg` if found
 
 ### Configuration OPTIONS
 
-* `access-token` - The DigitalOcean access token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel.
+* `access-token` - The DigitalOcean access token. You can generate a token in the [Apps & API](https://cloud.digitalocean.com/settings/applications) Of the DigitalOcean control panel or use `doit auth login`.
 * `output` - Type of output to display results in. Choices are `json` or `text`. If not supplied, `doit` will default to `text`.
 
 Example:
@@ -60,3 +61,7 @@ Example:
 
 `doit`'s dependencies are managed by [godep](https:/.com/tools/godep). To add new packages, you must
 run `godep save ./...` to update the vendored dependencies. External dependencies have been rewritten using `godep`.
+
+## Releasing
+
+To build `doit` for all it's platforms, run `script/build.sh <version>`. To upload `doit` to Github, run `script/release.sh <version>`. A valid `GITHUB_TOKEN` environment variable with access to the `bryanl/doit` repository will be required.

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/bryanl/doit-server"
+	"github.com/gorilla/websocket"
 )
 
 func TestAuth_retrieveCredentials(t *testing.T) {
@@ -21,7 +23,9 @@ func TestAuth_retrieveCredentials(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	ac, err := retrieveAuthCredentials(ts.URL)
+	dsa := newDoitServerAuth()
+	dsa.url = ts.URL
+	ac, err := dsa.retrieveAuthCredentials()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,12 +37,14 @@ func TestAuth_retrieveCredentials(t *testing.T) {
 }
 
 func TestAuth_createAuthURL(t *testing.T) {
-	serverURL := "http://example.com"
+	dsa := newDoitServerAuth()
+	dsa.url = "http://example.com"
+
 	ac := &doitserver.AuthCredentials{
 		ID: "id",
 		CS: "cs",
 	}
-	u, err := createAuthURL(serverURL, ac)
+	u, err := dsa.createAuthURL(ac)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,5 +67,142 @@ func TestAuth_createAuthURL(t *testing.T) {
 
 	if got, want := q.Get("id"), "id"; got != want {
 		t.Fatalf("createAuthURL() id param = %q, want = %q", got, want)
+	}
+}
+
+func TestAuth_createAuthURL_with_keypairs(t *testing.T) {
+	dsa := newDoitServerAuth()
+	dsa.url = "http://example.com"
+	ac := &doitserver.AuthCredentials{
+		ID: "id",
+		CS: "cs",
+	}
+	u, err := dsa.createAuthURL(ac, keyPair{k: "foo", v: "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newU, err := url.Parse(u)
+
+	if got, want := newU.Host, "example.com"; got != want {
+		t.Fatalf("createAuthURL() Host = %q, want = %q", got, want)
+	}
+
+	if got, want := newU.Path, "/auth/digitalocean"; got != want {
+		t.Fatalf("createAuthURL() Path = %q, want = %q", got, want)
+	}
+
+	q := newU.Query()
+
+	if got, want := q.Get("cs"), "cs"; got != want {
+		t.Fatalf("createAuthURL() cs param = %q, want = %q", got, want)
+	}
+
+	if got, want := q.Get("id"), "id"; got != want {
+		t.Fatalf("createAuthURL() id param = %q, want = %q", got, want)
+	}
+
+	if got, want := q.Get("foo"), "bar"; got != want {
+		t.Fatalf("createAuthURL() foo param = %q, want = %q", got, want)
+	}
+}
+
+func TestAuth_initAuthCLI(t *testing.T) {
+	dsa := newDoitServerAuth()
+
+	ac := &doitserver.AuthCredentials{
+		ID: "id",
+		CS: "cs",
+	}
+
+	go func() {
+		s, err := dsa.initAuthCLI(ac)
+		if err != nil {
+			t.Fatalf("initAuthCLI() unexpected error: %v", err)
+		}
+
+		if got, want := s, "token"; got != want {
+			t.Fatalf("initAuthCLI() = %q; want = %q", got, want)
+		}
+	}()
+
+	os.Stdin.Write([]byte("token\n"))
+}
+
+func TestAuth_initAuth(t *testing.T) {
+	dsa := newDoitServerAuth()
+	dsa.url = "http://example.com"
+	dsa.browserOpen = func(u string) error {
+		return nil
+	}
+	dsa.monitorAuth = func(u string, ac *doitserver.AuthCredentials) (*doitserver.TokenResponse, error) {
+		return &doitserver.TokenResponse{
+			AccessToken: "access-token",
+		}, nil
+	}
+	ac := &doitserver.AuthCredentials{
+		ID: "id",
+		CS: "cs",
+	}
+
+	token, err := dsa.initAuth(ac)
+	if err != nil {
+		t.Fatalf("initAuth() unexpected error: %v", err)
+	}
+
+	if got, want := token, "access-token"; got != want {
+		t.Fatalf("initAuth() token = %q; want = %q", got, want)
+	}
+}
+
+func TestAuth_monitorAuthWS(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("websocket upgrade error: %v", err)
+		}
+
+		var readAC doitserver.AuthCredentials
+		err = ws.ReadJSON(&readAC)
+		if err != nil {
+			t.Fatalf("read auth credentials error: %v", err)
+		}
+
+		if got, want := readAC.CS, "cs"; got != want {
+			t.Fatalf("server AuthCredentials CS = %q; want = %q", got, want)
+		}
+
+		if got, want := readAC.ID, "id"; got != want {
+			t.Fatalf("server AuthCredentials ID = %q; want = %q", got, want)
+		}
+
+		writeTR := doitserver.TokenResponse{
+			AccessToken: "access-token",
+		}
+
+		err = ws.WriteJSON(&writeTR)
+		if err != nil {
+			t.Fatalf("write token respose error: %v", err)
+		}
+
+		err = ws.Close()
+		if err != nil {
+			t.Fatalf("websock close: %v", err)
+		}
+	}))
+
+	ac := &doitserver.AuthCredentials{
+		ID: "id",
+		CS: "cs",
+	}
+
+	tr, err := monitorAuthWS(ts.URL, ac)
+	if err != nil {
+		t.Fatalf("monitorAuthWS() unexpected error: %v", err)
+	}
+
+	if got, want := tr.AccessToken, "access-token"; got != want {
+		t.Fatalf("monitorAuthWS() AccessToken = %q; want = %q", got, want)
 	}
 }


### PR DESCRIPTION
If `doit is run from a linux CLI with no `DISPLAY` environment env,
or if environment variable `CLIAUTH` is present, use a browserless 
token retrieve process