### PR TITLE
doit: don't block on droplet create errors

### DIFF
--- a/commands/droplets.go
+++ b/commands/droplets.go
@@ -180,7 +180,7 @@ func RunDropletCreate(c *cmdConfig) error {
 	ds := c.dropletsService()
 
 	var wg sync.WaitGroup
-	errs := make(chan error)
+	errs := make(chan error, len(c.args))
 	for _, name := range c.args {
 		dcr := &godo.DropletCreateRequest{
 			Name:              name,


### PR DESCRIPTION
Hey @bryanl! I think this might be the root cause of #51!

When `doit` creates droplets, it creates a channel to collect all of the errors and expose them. Because the errors channel is not buffered and there's no consumer, we block on sending to the channel, which never frees up the WaitGroup.

By creating a buffered channel with the number of create operations we're doing, we'll never block on sending an error during a create, and we drain the WaitGroup properly. 